### PR TITLE
[TASK-48] feat: GET /sketches

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,11 @@
 require("dotenv").config();
-const createError = require("http-errors");
 const express = require("express");
 const path = require("path");
 const logger = require("morgan");
 const cors = require("cors");
+
+const notFoundErrorHandler = require("./middlewares/notFoundErrorHandler");
+const errorHandler = require("./middlewares/errorHandler");
 
 const usersRouter = require("./routes/users");
 const loginRouter = require("./routes/login");
@@ -33,20 +35,7 @@ app.use(express.static(path.join(__dirname, "public")));
 app.use("/users", usersRouter);
 app.use("/login", loginRouter);
 
-// catch 404 and forward to error handler
-app.use(function (req, res, next) {
-  next(createError(404));
-});
-
-// error handler
-app.use(function (err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get("env") === "development" ? err : {};
-
-  // render the error page
-  res.status(err.status || 500);
-  res.render("error");
-});
+app.use(notFoundErrorHandler);
+app.use(errorHandler);
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ const mongoose = require("mongoose");
 
 const connectToDatabase = async () => {
   try {
-    await mongoose.connect(process.env.SECRET_URL);
+    await mongoose.connect(process.env.MONGODB_URI);
 
     console.log("connected");
   } catch (error) {

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const errorHandler = require("./middlewares/errorHandler");
 
 const usersRouter = require("./routes/users");
 const loginRouter = require("./routes/login");
+const sketchesRouter = require("./routes/sketches");
 
 const app = express();
 
@@ -34,6 +35,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/users", usersRouter);
 app.use("/login", loginRouter);
+app.use("/sketches", sketchesRouter);
 
 app.use(notFoundErrorHandler);
 app.use(errorHandler);

--- a/constants/number.js
+++ b/constants/number.js
@@ -1,0 +1,4 @@
+exports.NUMBER = {
+  DEFAULT_PER_PAGE: 3,
+  DEFAULT_PAGE: 1,
+};

--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -1,0 +1,40 @@
+const createError = require("http-errors");
+const { StatusCodes, ReasonPhrases } = require("http-status-codes");
+const Sketch = require("../models/Sketch");
+const { NUMBER } = require("../constants/number");
+
+exports.getSketches = async (req, res, next) => {
+  const perPage = req.query.per_page || NUMBER.DEFAULT_PER_PAGE;
+  const page = req.query.page || NUMBER.DEFAULT_PAGE;
+
+  if (isNaN(perPage) || isNaN(page)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+    return;
+  }
+
+  try {
+    const startIndex = (page - 1) * perPage;
+    const totalItems = await Sketch.countDocuments({ isPublic: true });
+
+    const sketchesUrl = await Sketch.find({ isPublic: true })
+      .sort({ _id: 1 })
+      .select({
+        imageUrl: 1,
+        _id: 0,
+      })
+      .limit(perPage)
+      .skip(startIndex);
+
+    res.json({
+      status: "ok",
+      sketchesUrl: { totalItems, list: sketchesUrl },
+    });
+  } catch (err) {
+    next(
+      createError(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        ReasonPhrases.INTERNAL_SERVER_ERROR,
+      ),
+    );
+  }
+};

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,13 +1,12 @@
 const { StatusCodes, ReasonPhrases } = require("http-status-codes");
 
 const errorHandler = async (err, req, res, next) => {
-  res.locals.error = req.app.get("env") === "development" ? err : {};
-  res.locals.message = err.message || ReasonPhrases.INTERNAL_SERVER_ERROR;
+  const message = err.message || ReasonPhrases.INTERNAL_SERVER_ERROR;
 
   res.status(err.status || StatusCodes.INTERNAL_SERVER_ERROR);
   res.json({
     status: "error",
-    message: res.locals.message,
+    message,
   });
 };
 

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,0 +1,14 @@
+const { StatusCodes, ReasonPhrases } = require("http-status-codes");
+
+const errorHandler = async (err, req, res, next) => {
+  res.locals.error = req.app.get("env") === "development" ? err : {};
+  res.locals.message = err.message || ReasonPhrases.INTERNAL_SERVER_ERROR;
+
+  res.status(err.status || StatusCodes.INTERNAL_SERVER_ERROR);
+  res.json({
+    status: "error",
+    message: res.locals.message,
+  });
+};
+
+module.exports = errorHandler;

--- a/middlewares/notFoundErrorHandler.js
+++ b/middlewares/notFoundErrorHandler.js
@@ -1,0 +1,8 @@
+const createError = require("http-errors");
+const { StatusCodes, ReasonPhrases } = require("http-status-codes");
+
+const notFoundErrorHandler = async (req, res, next) => {
+  return next(createError(StatusCodes.NOT_FOUND, ReasonPhrases.NOT_FOUND));
+};
+
+module.exports = notFoundErrorHandler;

--- a/models/Sketch.js
+++ b/models/Sketch.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+const { Schema } = mongoose;
+
+const sketchSchema = new Schema(
+  {
+    _id: { type: String },
+    userId: { type: mongoose.Types.ObjectId, required: true, ref: "User" },
+    title: String,
+    type: { type: String, enum: ["basic", "cartoon"] },
+    isPublic: { type: Boolean, index: true },
+    imageUrl: String,
+    backgroundImageUrl: String,
+    canvas: {
+      person: [
+        {
+          type: {
+            type: String,
+            enum: ["head", "body", "bottom", "scene", "face"],
+          },
+          zIndex: Number,
+          location: { top: String, left: String },
+          url: String,
+        },
+      ],
+    },
+    items: [
+      {
+        type: { type: String, enum: ["item"] },
+        zIndex: Number,
+        location: { top: String, left: String },
+        url: String,
+      },
+    ],
+    comments: [{ type: String, ref: "Comment", required: true }],
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model("Sketch", sketchSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "~4.16.1",
         "firebase-admin": "^11.10.1",
         "http-errors": "~1.6.3",
+        "http-status-codes": "^2.2.0",
         "mongoose": "^7.4.0",
         "morgan": "~1.9.1"
       },
@@ -2052,6 +2053,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "optional": true
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "~4.16.1",
     "firebase-admin": "^11.10.1",
     "http-errors": "~1.6.3",
+    "http-status-codes": "^2.2.0",
     "mongoose": "^7.4.0",
     "morgan": "~1.9.1"
   },

--- a/routes/sketches.js
+++ b/routes/sketches.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const { isAuthenticated } = require("../middlewares/authenticate");
+const sketchesController = require("../controllers/sketches.controller");
+
+router.get("/", isAuthenticated, sketchesController.getSketches);
+
+module.exports = router;


### PR DESCRIPTION
## 작업 요약

리뷰어 님, 안녕하세요!
본 PR에는 다음의 작업 내역이 담겨있습니다.

- 사용자가 작성한 스케치 데이터를 저장하기 위한 용도로 Sketch 스키마를 생성
- mongoose에서 제공하는 `sort()`, `limit()`, `skip()` 메소드를 이용하여 페이지네이션을 구현
- 에러 처리 미들웨어 추가(`errorHandler`, `notFoundErrorHandler`)
- 페이지 관련 기본 값을 상수화

## 참고 사항
- HTTP 상태 코드, 메시지를 편리하게 상수화하도록 해주는 [http-status-codes](https://www.npmjs.com/package/http-status-codes) 라이브러리를 추가
- 스케치 데이터 생성 API가 개발되지 않았기 때문에 MongoDB에 mock 데이터를 추가하여 개발

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

리뷰해주셔서 감사합니다! 🙏 
