### PR TITLE
[TASK-48] feat: GET /sketches | 페이지 당 아이템 수 기본값 변수명 변경 등

### DIFF
--- a/constants/number.js
+++ b/constants/number.js
@@ -1,4 +1,4 @@
 exports.NUMBER = {
-  DEFAULT_PER_PAGE: 3,
+  DEFAULT_ITEMS_LIMIT: 3,
   DEFAULT_PAGE: 1,
 };

--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -1,9 +1,12 @@
 const createError = require("http-errors");
 const { StatusCodes, ReasonPhrases } = require("http-status-codes");
+
 const Sketch = require("../models/Sketch");
+
+const { isPageValid } = require("../utils");
+
 const { NUMBER } = require("../constants/number");
 const { TEXT } = require("../constants/text");
-const { isPageValid } = require("../utils");
 
 exports.getSketches = async (req, res, next) => {
   const perPage = req.query.per_page || NUMBER.DEFAULT_ITEMS_LIMIT;

--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -24,6 +24,7 @@ exports.getSketches = async (req, res, next) => {
   try {
     const startIndex = (page - 1) * perPage;
     const totalItems = await Sketch.countDocuments({ isPublic: true });
+    const totalPages = Math.ceil(totalItems / perPage);
 
     const sketchesUrl = await Sketch.find({ isPublic: true })
       .sort({ _id: 1 })
@@ -36,7 +37,7 @@ exports.getSketches = async (req, res, next) => {
 
     res.json({
       status: TEXT.OK,
-      sketchesUrl: { totalItems, list: sketchesUrl },
+      sketchesUrl: { totalItems, totalPages, list: sketchesUrl },
     });
   } catch (error) {
     next(

--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -5,7 +5,7 @@ const { NUMBER } = require("../constants/number");
 const { TEXT } = require("../constants/text");
 
 exports.getSketches = async (req, res, next) => {
-  const perPage = req.query.per_page || NUMBER.DEFAULT_PER_PAGE;
+  const perPage = req.query.per_page || NUMBER.DEFAULT_ITEMS_LIMIT;
   const page = req.query.page || NUMBER.DEFAULT_PAGE;
 
   if (isNaN(perPage) || isNaN(page)) {

--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -3,12 +3,19 @@ const { StatusCodes, ReasonPhrases } = require("http-status-codes");
 const Sketch = require("../models/Sketch");
 const { NUMBER } = require("../constants/number");
 const { TEXT } = require("../constants/text");
+const { isPageValid } = require("../utils");
 
 exports.getSketches = async (req, res, next) => {
   const perPage = req.query.per_page || NUMBER.DEFAULT_ITEMS_LIMIT;
   const page = req.query.page || NUMBER.DEFAULT_PAGE;
 
   if (isNaN(perPage) || isNaN(page)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+
+    return;
+  }
+
+  if (!isPageValid(perPage) || !isPageValid(page)) {
     next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
 
     return;

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,9 @@
+exports.isPageValid = (page) => {
+  const parsedPage = Number(page);
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## 작업 요약

GET /sketches API에 다음 사항을 반영하였습니다.
- 페이지 당 아이템 수 기본값 변수명 변경(`DEFAULT_PER_PAGE` > `DEFAULT_ITEMS_LIMIT`) 
- 전체 페이지 수(`totalPages`)를 응답 데이터에 추가
- 모듈 임포트 순서 조정

## 참고 사항

- 없음.

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---