### PR TITLE
[TASK-47] feat: GET /units

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,13 +12,15 @@ const loginRouter = require("./routes/login");
 const sketchesRouter = require("./routes/sketches");
 const unitsRouter = require("./routes/units");
 
+const { CONFIG } = require("./constants/config");
+
 const app = express();
 
 const mongoose = require("mongoose");
 
 const connectToDatabase = async () => {
   try {
-    await mongoose.connect(process.env.MONGODB_URI);
+    await mongoose.connect(CONFIG.MONGODB_URI);
 
     console.log("connected");
   } catch (error) {

--- a/constants/config.js
+++ b/constants/config.js
@@ -1,0 +1,7 @@
+exports.CONFIG = {
+  MONGODB_URI: process.env.MONGODB_URI,
+  AWS_ACCESS_KEY: process.env.AWS_ACCESS_KEY,
+  AWS_SECRET_KEY: process.env.AWS_SECRET_KEY,
+  AWS_S3_BUCKET_NAME: process.env.AWS_S3_BUCKET_NAME,
+  AWS_S3_REGION: process.env.AWS_S3_REGION,
+};

--- a/constants/options.js
+++ b/constants/options.js
@@ -1,0 +1,3 @@
+exports.OPTIONS = {
+  UNIT_TYPE: new Set(["head", "body", "bottom", "scene", "face", "item"]),
+};

--- a/controllers/units.controller.js
+++ b/controllers/units.controller.js
@@ -1,11 +1,56 @@
 const createError = require("http-errors");
 const { StatusCodes, ReasonPhrases } = require("http-status-codes");
+
+const { getS3Client, getListObjectsCommand } = require("../utils/s3Config");
+const { isPageValid } = require("../utils");
+
 const { TEXT } = require("../constants/text");
+const { CONFIG } = require("../constants/config");
+const { OPTIONS } = require("../constants/options");
+const { NUMBER } = require("../constants/number");
 
 exports.getUnits = async (req, res, next) => {
+  const { per_page, page, type } = req.query;
+
+  if (isNaN(per_page) || isNaN(page)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+
+    return;
+  }
+
+  if (!isPageValid(per_page) || !isPageValid(page)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+
+    return;
+  }
+
+  if (!type || !OPTIONS.UNIT_TYPE.has(type)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+
+    return;
+  }
+
+  const perPageNumber = Number(per_page) || NUMBER.DEFAULT_ITEMS_LIMIT;
+  const pageNumber = Number(page) || NUMBER.DEFAULT_PAGE;
+
   try {
+    const objects = await getS3Objects(type);
+
+    const startIndex = (pageNumber - 1) * perPageNumber;
+    const endIndex = startIndex + perPageNumber;
+
+    const totalItems = objects.length;
+    const totalPages = Math.ceil(totalItems / perPageNumber);
+
+    const slicedObjects = objects.slice(startIndex, endIndex);
+
     res.json({
       status: TEXT.OK,
+      units: {
+        totalItems,
+        totalPages,
+        list: slicedObjects,
+      },
     });
   } catch (error) {
     next(
@@ -15,4 +60,24 @@ exports.getUnits = async (req, res, next) => {
       ),
     );
   }
+};
+
+const getS3Objects = async (type) => {
+  const s3Client = getS3Client();
+
+  const listObjectsCommand = getListObjectsCommand(
+    CONFIG.AWS_S3_BUCKET_NAME,
+    `units/${type}/`,
+    "/",
+  );
+
+  const objects = await s3Client.send(listObjectsCommand);
+
+  const filteredObjects = objects.Contents.filter(
+    (item) => !item.Key.endsWith("/"),
+  ).map((item) => ({
+    url: `https://${CONFIG.AWS_S3_BUCKET_NAME}.s3.${CONFIG.AWS_S3_REGION}.amazonaws.com/${item.Key}`,
+  }));
+
+  return filteredObjects;
 };

--- a/utils/s3Config.js
+++ b/utils/s3Config.js
@@ -1,0 +1,27 @@
+const { S3Client, ListObjectsV2Command } = require("@aws-sdk/client-s3");
+
+const { CONFIG } = require("../constants/config");
+
+exports.getS3Client = () => {
+  const clientConfig = {
+    region: CONFIG.AWS_S3_REGION,
+    credentials: {
+      accessKeyId: CONFIG.AWS_ACCESS_KEY,
+      secretAccessKey: CONFIG.AWS_SECRET_KEY,
+    },
+  };
+
+  const s3Client = new S3Client(clientConfig);
+
+  return s3Client;
+};
+
+exports.getListObjectsCommand = (bucketName, prefix, delimiter) => {
+  const listObjectsCommand = new ListObjectsV2Command({
+    Bucket: bucketName,
+    Prefix: prefix,
+    Delimiter: delimiter || "/",
+  });
+
+  return listObjectsCommand;
+};


### PR DESCRIPTION
## 작업 요약

GET /units API에 다음 사항을 반영하였습니다.
- units 컨트롤러에 `getUnits` 메소드 추가
- s3 클라이언트, Objects 리스트 반환 유틸 함수 추가
- 상수화(환경 설정 관련 변수, 옵션 관련 변수)

## 참고 사항
- 없습니다.

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
