### PR TITLE
[TASK-47] fix: GET /units

### DIFF
--- a/constants/options.js
+++ b/constants/options.js
@@ -1,3 +1,4 @@
 exports.OPTIONS = {
   UNIT_TYPE: new Set(["head", "body", "bottom", "scene", "face", "item"]),
+  SKETCH_TYPE: new Set(["cartoon", "illustration"]),
 };

--- a/controllers/units.controller.js
+++ b/controllers/units.controller.js
@@ -35,6 +35,12 @@ exports.getUnits = async (req, res, next) => {
     return;
   }
 
+  if (!OPTIONS.SKETCH_TYPE.has(sketchType)) {
+    next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
+
+    return;
+  }
+
   const perPageNumber = Number(per_page) || NUMBER.DEFAULT_ITEMS_LIMIT;
   const pageNumber = Number(page) || NUMBER.DEFAULT_PAGE;
 


### PR DESCRIPTION
## 작업 요약

GET /units API의 수정 작업을 다음과 같이 진행하였습니다.

- 정의된 스케치 타입("cartoon", "illustration") 이외의 쿼리 파라미터로 조회 시 400 오류 반환

## 참고 사항

- [API 문서](https://mirage-ceres-274.notion.site/BE-GET-units-9480c6f38cb445a5a4c398be24e87a3b?pvs=4)를 업데이트하였습니다. 이용 시 참고해주세요!

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
