### PR TITLE
[TASK-43] fix: 이미지 관련 버퍼 생성 시 사용되는 인자 변경

### DIFF
--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -135,7 +135,7 @@ exports.createSketch = async (req, res, next) => {
     const saveSketch = async () => {
       try {
         const s3Client = getS3Client();
-        const buffer = Buffer.from(image, "base64");
+        const buffer = Buffer.from(image.split(",")[1], "base64");
 
         const imageId = new Date().toISOString();
         const imageFileName = `sketches/${user._id}/${imageId}.png`;


### PR DESCRIPTION
## 작업 요약

POST /users/{user_id}/sketches API를 이용하여 스케치 저장을 테스트하던 중에
s3 쪽으로 전송한 이미지가 아래와 같이 열리지 않는 것을 발견하였습니다.

![TASK-43 issue](https://github.com/team-desire/hello-sketch-server/assets/123475341/35221269-2e8e-40df-8b78-c6991b9a7dfd)

버퍼 생성 시 사용한 인자가 잘못되어 있어서 발생한 오류였으며,
코드 수정 후 다시 테스트 한 결과, 아래와 같이 정상적으로 이미지가 저장되는 것을 확인하였습니다.

![TASK-43 issue-ok](https://github.com/team-desire/hello-sketch-server/assets/123475341/8171a229-53c4-4f8d-ad5e-653388515173)

## 참고 사항

- [[참고자료] Node.js에서 Base64 문자열을 인코딩, 디코딩하는 방법](https://stackabuse.com/encoding-and-decoding-base64-strings-in-node-js/)

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
