### PR TITLE
[TASK-43] fix: isPublic 관련 유효성 검증 로직 수정

### DIFF
--- a/controllers/sketches.controller.js
+++ b/controllers/sketches.controller.js
@@ -121,7 +121,7 @@ exports.createSketch = async (req, res, next) => {
 
   const { title, type, isPublic, image } = req.body;
 
-  if (!type || !isPublic || !image) {
+  if (!type || !image) {
     next(createError(StatusCodes.BAD_REQUEST, ReasonPhrases.BAD_REQUEST));
   }
 


### PR DESCRIPTION
## 작업 요약

테스트 중, `isPublic` 값이 falsy인 경우에 유효성 검증을 통과하지 못하는 케이스가 발견되어서 수정하였습니다.

## 참고 사항

- 없습니다.

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
