### PR TITLE
[TASK-35] chore: Elastic Beanstalk 관련 파일 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ node_modules/
 .vscode
 
 ServiceAccount.json
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml


### PR DESCRIPTION
## 작업 요약

AWS Elastic Beanstalk 관련 설정 파일이 Git에 올라가지 않게 .gitignore를 수정하였습니다.

## 참고 사항

- [[참고자료] EB CLI 설정 방법](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-configuration.html)

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
